### PR TITLE
add platform qualifier for gem

### DIFF
--- a/purl/src/qualifiers/well_known.rs
+++ b/purl/src/qualifiers/well_known.rs
@@ -8,6 +8,7 @@ use hex::{FromHex, ToHex};
 
 use crate::{copy_as_lowercase, ParseError, SmallString};
 
+pub mod gem;
 pub mod maven;
 
 /// A type that has an associated qualifier key.

--- a/purl/src/qualifiers/well_known/gem.rs
+++ b/purl/src/qualifiers/well_known/gem.rs
@@ -1,0 +1,7 @@
+//! Known qualifier types for [gem].
+//!
+//! [gem]: https://github.com/package-url/purl-spec/blob/master/PURL-TYPES.rst#gem
+
+use super::str_ref_qualifier;
+
+str_ref_qualifier!(Platform, "platform", "platform");

--- a/purl/src/qualifiers/well_known/maven.rs
+++ b/purl/src/qualifiers/well_known/maven.rs
@@ -1,4 +1,6 @@
-//! Known qualifier types for Maven.
+//! Known qualifier types for [maven].
+//!
+//! [maven]: https://github.com/package-url/purl-spec/blob/master/PURL-TYPES.rst#maven
 
 use super::str_ref_qualifier;
 


### PR DESCRIPTION
# Overview
This PR adds a platform qualifier for the gem type.

# Checklist
- [ ] Does this PR have an associated issue?
- [ ] Have you ensured that you have met the expected acceptance criteria?
- [ ] Have you created sufficient tests?

# Issue
What issue(s) does this PR close. Use the `closes #<issueNum>` here.
