### PR TITLE
implement display for package type

### DIFF
--- a/purl/src/package_type.rs
+++ b/purl/src/package_type.rs
@@ -1,6 +1,7 @@
 //! Support for known package types.
 
 use std::borrow::Cow;
+use std::fmt;
 use std::str::FromStr;
 
 use phf::phf_map;
@@ -163,6 +164,12 @@ impl From<PackageType> for &'static str {
 impl AsRef<str> for PackageType {
     fn as_ref(&self) -> &str {
         self.name()
+    }
+}
+
+impl fmt::Display for PackageType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.name())
     }
 }
 


### PR DESCRIPTION
# Overview
This PR adds a display implementation for `PackageType` to improve ergonomics when formatting strings.

# Checklist
- [ ] Does this PR have an associated issue?
- [ ] Have you ensured that you have met the expected acceptance criteria?
- [ ] Have you created sufficient tests?

# Issue
What issue(s) does this PR close. Use the `closes #<issueNum>` here.
