### PR TITLE
fix golang

### DIFF
--- a/purl_test/src/lib.rs
+++ b/purl_test/src/lib.rs
@@ -740,3 +740,195 @@ fn unsupported_composer_names_are_not_case_sensitive() {
         "composer"
     );
 }
+#[test]
+/// valid go purl with uppercase in namespace
+fn valid_go_purl_with_uppercase_in_namespace() {
+    let parsed =
+        match Purl::from_str("pkg:golang/github.com/GoogleCloudPlatform/cloud-sql-proxy/v2") {
+            Ok(purl) => purl,
+            Err(error) => {
+                panic!(
+                    "Failed to parse valid purl {:?}: {}",
+                    "pkg:golang/github.com/GoogleCloudPlatform/cloud-sql-proxy/v2", error
+                )
+            },
+        };
+    assert_eq!(&PackageType::Golang, parsed.package_type(), "Incorrect package type");
+    assert_eq!(
+        Some("github.com/GoogleCloudPlatform/cloud-sql-proxy"),
+        parsed.namespace(),
+        "Incorrect namespace"
+    );
+    assert_eq!("v2", parsed.name(), "Incorrect name");
+    assert_eq!(None, parsed.version(), "Incorrect version");
+    assert_eq!(None, parsed.subpath(), "Incorrect subpath");
+    let expected_qualifiers: HashMap<&str, &str> = HashMap::new();
+    assert_eq!(
+        expected_qualifiers,
+        parsed.qualifiers().iter().map(|(k, v)| (k.as_str(), v)).collect::<HashMap<&str, &str>>()
+    );
+    assert_eq!(
+        "pkg:golang/github.com/GoogleCloudPlatform/cloud-sql-proxy/v2",
+        &parsed.to_string(),
+        "Incorrect string representation"
+    );
+}
+#[test]
+/// valid go purl with uppercase in name
+fn valid_go_purl_with_uppercase_in_name() {
+    let parsed = match Purl::from_str("pkg:golang/example.com/A") {
+        Ok(purl) => purl,
+        Err(error) => {
+            panic!("Failed to parse valid purl {:?}: {}", "pkg:golang/example.com/A", error)
+        },
+    };
+    assert_eq!(&PackageType::Golang, parsed.package_type(), "Incorrect package type");
+    assert_eq!(Some("example.com"), parsed.namespace(), "Incorrect namespace");
+    assert_eq!("A", parsed.name(), "Incorrect name");
+    assert_eq!(None, parsed.version(), "Incorrect version");
+    assert_eq!(None, parsed.subpath(), "Incorrect subpath");
+    let expected_qualifiers: HashMap<&str, &str> = HashMap::new();
+    assert_eq!(
+        expected_qualifiers,
+        parsed.qualifiers().iter().map(|(k, v)| (k.as_str(), v)).collect::<HashMap<&str, &str>>()
+    );
+    assert_eq!("pkg:golang/example.com/A", &parsed.to_string(), "Incorrect string representation");
+}
+#[test]
+/// valid go purl without namespace
+fn valid_go_purl_without_namespace() {
+    let parsed = match Purl::from_str("pkg:golang/v.io") {
+        Ok(purl) => purl,
+        Err(error) => {
+            panic!("Failed to parse valid purl {:?}: {}", "pkg:golang/v.io", error)
+        },
+    };
+    assert_eq!(&PackageType::Golang, parsed.package_type(), "Incorrect package type");
+    assert_eq!(None, parsed.namespace(), "Incorrect namespace");
+    assert_eq!("v.io", parsed.name(), "Incorrect name");
+    assert_eq!(None, parsed.version(), "Incorrect version");
+    assert_eq!(None, parsed.subpath(), "Incorrect subpath");
+    let expected_qualifiers: HashMap<&str, &str> = HashMap::new();
+    assert_eq!(
+        expected_qualifiers,
+        parsed.qualifiers().iter().map(|(k, v)| (k.as_str(), v)).collect::<HashMap<&str, &str>>()
+    );
+    assert_eq!("pkg:golang/v.io", &parsed.to_string(), "Incorrect string representation");
+}
+#[test]
+/// valid npm purl with uppercase in name
+fn valid_npm_purl_with_uppercase_in_name() {
+    let parsed = match Purl::from_str("pkg:npm/parseUri") {
+        Ok(purl) => purl,
+        Err(error) => {
+            panic!("Failed to parse valid purl {:?}: {}", "pkg:npm/parseUri", error)
+        },
+    };
+    assert_eq!(&PackageType::Npm, parsed.package_type(), "Incorrect package type");
+    assert_eq!(None, parsed.namespace(), "Incorrect namespace");
+    assert_eq!("parseUri", parsed.name(), "Incorrect name");
+    assert_eq!(None, parsed.version(), "Incorrect version");
+    assert_eq!(None, parsed.subpath(), "Incorrect subpath");
+    let expected_qualifiers: HashMap<&str, &str> = HashMap::new();
+    assert_eq!(
+        expected_qualifiers,
+        parsed.qualifiers().iter().map(|(k, v)| (k.as_str(), v)).collect::<HashMap<&str, &str>>()
+    );
+    assert_eq!("pkg:npm/parseUri", &parsed.to_string(), "Incorrect string representation");
+}
+#[test]
+/// valid cargo purl with uppercase in name
+fn valid_cargo_purl_with_uppercase_in_name() {
+    let parsed = match Purl::from_str("pkg:cargo/Inflector") {
+        Ok(purl) => purl,
+        Err(error) => {
+            panic!("Failed to parse valid purl {:?}: {}", "pkg:cargo/Inflector", error)
+        },
+    };
+    assert_eq!(&PackageType::Cargo, parsed.package_type(), "Incorrect package type");
+    assert_eq!(None, parsed.namespace(), "Incorrect namespace");
+    assert_eq!("Inflector", parsed.name(), "Incorrect name");
+    assert_eq!(None, parsed.version(), "Incorrect version");
+    assert_eq!(None, parsed.subpath(), "Incorrect subpath");
+    let expected_qualifiers: HashMap<&str, &str> = HashMap::new();
+    assert_eq!(
+        expected_qualifiers,
+        parsed.qualifiers().iter().map(|(k, v)| (k.as_str(), v)).collect::<HashMap<&str, &str>>()
+    );
+    assert_eq!("pkg:cargo/Inflector", &parsed.to_string(), "Incorrect string representation");
+}
+#[test]
+/// non-canonical nuget purl with uppercase in name
+fn non_canonical_nuget_purl_with_uppercase_in_name() {
+    let parsed = match Purl::from_str("pkg:nuget/Newtonsoft.Json") {
+        Ok(purl) => purl,
+        Err(error) => {
+            panic!("Failed to parse valid purl {:?}: {}", "pkg:nuget/Newtonsoft.Json", error)
+        },
+    };
+    assert_eq!(&PackageType::NuGet, parsed.package_type(), "Incorrect package type");
+    assert_eq!(None, parsed.namespace(), "Incorrect namespace");
+    assert_eq!("newtonsoft.json", parsed.name(), "Incorrect name");
+    assert_eq!(None, parsed.version(), "Incorrect version");
+    assert_eq!(None, parsed.subpath(), "Incorrect subpath");
+    let expected_qualifiers: HashMap<&str, &str> = HashMap::new();
+    assert_eq!(
+        expected_qualifiers,
+        parsed.qualifiers().iter().map(|(k, v)| (k.as_str(), v)).collect::<HashMap<&str, &str>>()
+    );
+    assert_eq!("pkg:nuget/newtonsoft.json", &parsed.to_string(), "Incorrect string representation");
+}
+#[test]
+/// non-canonical pypi purl with uppercase in name
+fn non_canonical_pypi_purl_with_uppercase_in_name() {
+    let parsed = match Purl::from_str("pkg:pypi/PyTest") {
+        Ok(purl) => purl,
+        Err(error) => {
+            panic!("Failed to parse valid purl {:?}: {}", "pkg:pypi/PyTest", error)
+        },
+    };
+    assert_eq!(&PackageType::PyPI, parsed.package_type(), "Incorrect package type");
+    assert_eq!(None, parsed.namespace(), "Incorrect namespace");
+    assert_eq!("pytest", parsed.name(), "Incorrect name");
+    assert_eq!(None, parsed.version(), "Incorrect version");
+    assert_eq!(None, parsed.subpath(), "Incorrect subpath");
+    let expected_qualifiers: HashMap<&str, &str> = HashMap::new();
+    assert_eq!(
+        expected_qualifiers,
+        parsed.qualifiers().iter().map(|(k, v)| (k.as_str(), v)).collect::<HashMap<&str, &str>>()
+    );
+    assert_eq!("pkg:pypi/pytest", &parsed.to_string(), "Incorrect string representation");
+}
+#[test]
+/// non-canonical pypi purl with specials in name
+fn non_canonical_pypi_purl_with_specials_in_name() {
+    let parsed = match Purl::from_str("pkg:pypi/_-.-_special_-.-_name_-.-_") {
+        Ok(purl) => purl,
+        Err(error) => {
+            panic!(
+                "Failed to parse valid purl {:?}: {}",
+                "pkg:pypi/_-.-_special_-.-_name_-.-_", error
+            )
+        },
+    };
+    assert_eq!(&PackageType::PyPI, parsed.package_type(), "Incorrect package type");
+    assert_eq!(None, parsed.namespace(), "Incorrect namespace");
+    assert_eq!("-special-name-", parsed.name(), "Incorrect name");
+    assert_eq!(None, parsed.version(), "Incorrect version");
+    assert_eq!(None, parsed.subpath(), "Incorrect subpath");
+    let expected_qualifiers: HashMap<&str, &str> = HashMap::new();
+    assert_eq!(
+        expected_qualifiers,
+        parsed.qualifiers().iter().map(|(k, v)| (k.as_str(), v)).collect::<HashMap<&str, &str>>()
+    );
+    assert_eq!("pkg:pypi/-special-name-", &parsed.to_string(), "Incorrect string representation");
+}
+#[test]
+/// invalid maven purl without namespace
+fn invalid_maven_purl_without_namespace() {
+    assert!(
+        Purl::from_str("pkg:maven/invalid").is_err(),
+        "{}",
+        "invalid maven purl without namespace"
+    );
+}

--- a/xtask/src/generate_tests.rs
+++ b/xtask/src/generate_tests.rs
@@ -15,6 +15,7 @@ use syn::parse_quote;
 use crate::workspace_dir;
 
 const TEST_SUITE_DATA: &str = include_str!("generate_tests/test-suite-data.json");
+const PHYLUM_TEST_SUITE_DATA: &str = include_str!("generate_tests/phylum-test-suite-data.json");
 const BLACKLIST: &[&str] = &[
     // NuGet package names are not case sensitive. package-url/purl-spec#226
     "nuget names are case sensitive",
@@ -39,11 +40,16 @@ struct Test<'a> {
 }
 
 pub fn main() {
-    let tests: Vec<Test> =
+    let purl_tests: Vec<Test> =
         serde_json::from_str(TEST_SUITE_DATA).expect("Could not read test-suite-data.json");
+    let phylum_tests: Vec<Test> = serde_json::from_str(PHYLUM_TEST_SUITE_DATA)
+        .expect("Could not read phylum-test-suite-data.json");
 
-    let tests =
-        tests.into_iter().filter(|t| !BLACKLIST.contains(&t.description)).map(test_to_tokens);
+    let tests = purl_tests
+        .into_iter()
+        .chain(phylum_tests)
+        .filter(|t| !BLACKLIST.contains(&t.description))
+        .map(test_to_tokens);
     let suite = parse_quote! {
         use std::collections::HashMap;
         use std::str::FromStr;

--- a/xtask/src/generate_tests/README.md
+++ b/xtask/src/generate_tests/README.md
@@ -1,2 +1,5 @@
-This is the test suite from the PURL spec repository:
+`test-suite-data.json` is the test suite from the PURL spec repository:
 https://github.com/package-url/purl-spec/blob/master/test-suite-data.json
+
+`phylum-test-suite-data.json` is additional cases that are not yet covered by the PURL spec
+repository test suite.

--- a/xtask/src/generate_tests/phylum-test-suite-data.json
+++ b/xtask/src/generate_tests/phylum-test-suite-data.json
@@ -1,0 +1,110 @@
+[
+  {
+    "description": "valid go purl with uppercase in namespace",
+    "purl": "pkg:golang/github.com/GoogleCloudPlatform/cloud-sql-proxy/v2",
+    "canonical_purl": "pkg:golang/github.com/GoogleCloudPlatform/cloud-sql-proxy/v2",
+    "type": "golang",
+    "namespace": "github.com/GoogleCloudPlatform/cloud-sql-proxy",
+    "name": "v2",
+    "version": null,
+    "qualifiers": null,
+    "subpath": null,
+    "is_invalid": false
+  },
+  {
+    "description": "valid go purl with uppercase in name",
+    "purl": "pkg:golang/example.com/A",
+    "canonical_purl": "pkg:golang/example.com/A",
+    "type": "golang",
+    "namespace": "example.com",
+    "name": "A",
+    "version": null,
+    "qualifiers": null,
+    "subpath": null,
+    "is_invalid": false
+  },
+  {
+    "description": "valid go purl without namespace",
+    "purl": "pkg:golang/v.io",
+    "canonical_purl": "pkg:golang/v.io",
+    "type": "golang",
+    "namespace": null,
+    "name": "v.io",
+    "version": null,
+    "qualifiers": null,
+    "subpath": null,
+    "is_invalid": false
+  },
+  {
+    "description": "valid npm purl with uppercase in name",
+    "purl": "pkg:npm/parseUri",
+    "canonical_purl": "pkg:npm/parseUri",
+    "type": "npm",
+    "namespace": null,
+    "name": "parseUri",
+    "version": null,
+    "qualifiers": null,
+    "subpath": null,
+    "is_invalid": false
+  },
+  {
+    "description": "valid cargo purl with uppercase in name",
+    "purl": "pkg:cargo/Inflector",
+    "canonical_purl": "pkg:cargo/Inflector",
+    "type": "cargo",
+    "namespace": null,
+    "name": "Inflector",
+    "version": null,
+    "qualifiers": null,
+    "subpath": null,
+    "is_invalid": false
+  },
+  {
+    "description": "non-canonical nuget purl with uppercase in name",
+    "purl": "pkg:nuget/Newtonsoft.Json",
+    "canonical_purl": "pkg:nuget/newtonsoft.json",
+    "type": "nuget",
+    "namespace": null,
+    "name": "newtonsoft.json",
+    "version": null,
+    "qualifiers": null,
+    "subpath": null,
+    "is_invalid": false
+  },
+  {
+    "description": "non-canonical pypi purl with uppercase in name",
+    "purl": "pkg:pypi/PyTest",
+    "canonical_purl": "pkg:pypi/pytest",
+    "type": "pypi",
+    "namespace": null,
+    "name": "pytest",
+    "version": null,
+    "qualifiers": null,
+    "subpath": null,
+    "is_invalid": false
+  },
+  {
+    "description": "non-canonical pypi purl with specials in name",
+    "purl": "pkg:pypi/_-.-_special_-.-_name_-.-_",
+    "canonical_purl": "pkg:pypi/-special-name-",
+    "type": "pypi",
+    "namespace": null,
+    "name": "-special-name-",
+    "version": null,
+    "qualifiers": null,
+    "subpath": null,
+    "is_invalid": false
+  },
+  {
+    "description": "invalid maven purl without namespace",
+    "purl": "pkg:maven/invalid",
+    "canonical_purl": null,
+    "type": null,
+    "namespace": null,
+    "name": null,
+    "version": null,
+    "qualifiers": null,
+    "subpath": null,
+    "is_invalid": true
+  }
+]


### PR DESCRIPTION
# Overview
Everything we had about Go was wrong.

The spec says the namespace is used to infer the location of the code so I made the namespace required. That's not exactly true. Go does not have separate namespaces and names. Namespaces are a PURL concept, and for Go PURLs you just split on the last slash so the PURL namespace+name looks like the Go name. It is possible to have a Go name that contains no slashes, in which case there is no PURL namespace.

The spec says that the namespace and name must be lowercase, but this is incorrect. Capitalization matters, and the Go tooling developers even have a name encoding scheme to ensure that modules with names differing only by capitalization do not cause conflicts on case-insensitive filesystems.

I moved the package type tests into a `phylum-test-suite-data.json`. Hopefully someday we can get these cases added to the spec repository.

# Checklist
- [ ] Does this PR have an associated issue?
- [ ] Have you ensured that you have met the expected acceptance criteria?
- [x] Have you created sufficient tests?

# Issue
What issue(s) does this PR close. Use the `closes #<issueNum>` here.
