### PR TITLE
Update crate readme to be compatible with crates.io

### DIFF
--- a/purl/README.md
+++ b/purl/README.md
@@ -10,6 +10,10 @@ This library supports PURLs at two levels:
 
 [PURL]: https://github.com/package-url/purl-spec
 [package-url/purl-spec#38]: https://github.com/package-url/purl-spec/issues/38
+[`GenericPurl`]: https://docs.rs/purl/0.1/purl/struct.GenericPurl.html
+[`Purl`]: https://docs.rs/purl/0.1/purl/type.Purl.html
+[`PackageType`]: https://docs.rs/purl/0.1/purl/enum.PackageType.html
+[`PurlShape`]: https://docs.rs/purl/0.1/purl/trait.PurlShape.html
 
 # Example
 

--- a/purl/README.md
+++ b/purl/README.md
@@ -22,30 +22,30 @@ use std::str::FromStr;
 
 use purl::GenericPurl;
 
-# fn main() -> Result<(), Box<dyn std::error::Error>> {
-let purl = GenericPurl::<String>::from_str(
-    "pkg:NPM/@acme/example@1.2.3?Checksum=sha256:\
-     E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855",
-)?;
-assert_eq!("npm", purl.package_type());
-assert_eq!(Some("@acme"), purl.namespace());
-assert_eq!("example", purl.name());
-assert_eq!(Some("1.2.3"), purl.version());
-// Normalization is performed during parsing.
-assert_eq!(
-    "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-    purl.qualifiers()["checksum"],
-);
-assert_eq!(
-    "pkg:npm/%40acme/example@1.2.3?checksum=sha256:\
-     e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-    &purl.to_string(),
-);
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let purl = GenericPurl::<String>::from_str(
+        "pkg:NPM/@acme/example@1.2.3?Checksum=sha256:\
+        E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855",
+    )?;
+    assert_eq!("npm", purl.package_type());
+    assert_eq!(Some("@acme"), purl.namespace());
+    assert_eq!("example", purl.name());
+    assert_eq!(Some("1.2.3"), purl.version());
+    // Normalization is performed during parsing.
+    assert_eq!(
+        "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        purl.qualifiers()["checksum"],
+    );
+    assert_eq!(
+        "pkg:npm/%40acme/example@1.2.3?checksum=sha256:\
+        e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        &purl.to_string(),
+    );
 
-let purl = purl.into_builder().without_version().without_qualifier("checksum").build()?;
-assert_eq!("pkg:npm/%40acme/example", &purl.to_string(),);
-# Ok(())
-# }
+    let purl = purl.into_builder().without_version().without_qualifier("checksum").build()?;
+    assert_eq!("pkg:npm/%40acme/example", &purl.to_string(),);
+    Ok(())
+}
 ```
 
 # Features


### PR DESCRIPTION
# Overview
This PR explicitly links from README.md to docs.rs. <code>[\`GenericPurl\`]</code> etc will automatically resolve to the appropriate documentation when used in a rustdoc context, but not when used in a crate readme file on crates.io.

Commented lines are removed from the example, because this is another feature that only works in rustdoc contexts.