### PR TITLE
bump version number

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -310,7 +310,7 @@ dependencies = [
 
 [[package]]
 name = "purl"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "hex",
  "maplit",

--- a/purl/Cargo.toml
+++ b/purl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "purl"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 description = "A Package URL implementation with customizable package types"
 repository = "https://github.com/phylum-dev/purl/"


### PR DESCRIPTION
This PR bumps the version number so we can release 0.1.1 with the new iterator for the checksum qualifier.