### PR TITLE
better align parsing with spec

### DIFF
--- a/purl/src/format.rs
+++ b/purl/src/format.rs
@@ -56,7 +56,7 @@ where
 
         if let Some(version) = self.version() {
             // The version is a continuation of the same path segment.
-            write!(f, "@{}", utf8_percent_encode(version, PURL_PATH_SEGMENT))?;
+            write!(f, "@{}", utf8_percent_encode(version, PURL_PATH))?;
         }
 
         if !self.parts.qualifiers.is_empty() {
@@ -156,18 +156,6 @@ mod tests {
         assert_eq!(
             "pkg:generic/a%23%2Fb%3F%2Fc%40",
             &GenericPurlBuilder::new(Cow::Borrowed("generic"), "a#/b?/c@")
-                .build()
-                .expect("Could not build PURL")
-                .to_string(),
-        );
-    }
-
-    #[test]
-    fn display_encodes_version_correctly() {
-        assert_eq!(
-            "pkg:generic/name@a%23%2Fb%3F%2Fc%40",
-            &GenericPurlBuilder::new(Cow::Borrowed("generic"), "name")
-                .with_version("a#/b?/c@")
                 .build()
                 .expect("Could not build PURL")
                 .to_string(),

--- a/purl/src/lib.rs
+++ b/purl/src/lib.rs
@@ -4,7 +4,6 @@
 use std::borrow::Cow;
 
 pub use builder::*;
-pub use format::*;
 #[cfg(feature = "package-type")]
 pub use package_type::*;
 pub use parse::*;

--- a/purl_test/src/lib.rs
+++ b/purl_test/src/lib.rs
@@ -1296,3 +1296,39 @@ fn unsupported_percent_signs_are_properly_encoded_and_decoded() {
         "Incorrect string representation"
     );
 }
+#[test]
+/// unsupported: version encoding
+fn unsupported_version_encoding() {
+    assert!(
+        matches!(
+            Purl::from_str("pkg:generic/name@a%23%2Fb%3F%2Fc%40"),
+            Err(PackageError::UnsupportedType)
+        ),
+        "Type {} is not supported",
+        "generic"
+    );
+    let parsed = match GenericPurl::<String>::from_str("pkg:generic/name@a%23%2Fb%3F%2Fc%40") {
+        Ok(purl) => purl,
+        Err(error) => {
+            panic!(
+                "Failed to parse valid purl {:?}: {}",
+                "pkg:generic/name@a%23%2Fb%3F%2Fc%40", error
+            )
+        },
+    };
+    assert_eq!("generic", parsed.package_type(), "Incorrect package type");
+    assert_eq!(None, parsed.namespace(), "Incorrect namespace");
+    assert_eq!("name", parsed.name(), "Incorrect name");
+    assert_eq!(Some("a#/b?/c@"), parsed.version(), "Incorrect version");
+    assert_eq!(None, parsed.subpath(), "Incorrect subpath");
+    let expected_qualifiers: HashMap<&str, &str> = HashMap::new();
+    assert_eq!(
+        expected_qualifiers,
+        parsed.qualifiers().iter().map(|(k, v)| (k.as_str(), v)).collect::<HashMap<&str, &str>>()
+    );
+    assert_eq!(
+        "pkg:generic/name@a%23/b%3F/c%40",
+        &parsed.to_string(),
+        "Incorrect string representation"
+    );
+}

--- a/xtask/src/generate_tests/phylum-test-suite-data.json
+++ b/xtask/src/generate_tests/phylum-test-suite-data.json
@@ -134,5 +134,14 @@
     },
     "subpath": "100%",
     "is_invalid": false
+  },
+  {
+    "description": "version encoding",
+    "purl": "pkg:generic/name@a%23%2Fb%3F%2Fc%40",
+    "canonical_purl": "pkg:generic/name@a%23/b%3F/c%40",
+    "type": "generic",
+    "name": "name",
+    "version": "a#/b?/c@",
+    "is_invalid": false
   }
 ]


### PR DESCRIPTION
# Overview
I was looking at package-url/packageurl-python#123 and found a case where parsing the canonical PURL requires following almost exactly the [parsing algorithm described in the spec](https://github.com/package-url/purl-spec/blob/master/PURL-SPECIFICATION.rst#how-to-parse-a-purl-string-in-its-components).

We need to be doing more rsplits and we need to rsplit the version from the name before rsplitting the name from the namespace. Otherwise, if the version contains a slash we get the wrong result.

The format test was ensuring slashes in the version were percent encoded, which is not part of the spec, but was required to be able to parse the resulting PURL string when using the incorrect parsing algorithm. I moved it into our test json so it covers both directions and we test deserialization for both the properly escaped and improperly escaped cases (followup PR for better coverage).

# Checklist
- [ ] Does this PR have an associated issue?
- [ ] Have you ensured that you have met the expected acceptance criteria?
- [x] Have you created sufficient tests?

# Issue
What issue(s) does this PR close. Use the `closes #<issueNum>` here.
