### PR TITLE
bump version number

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -310,7 +310,7 @@ dependencies = [
 
 [[package]]
 name = "purl"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "hex",
  "maplit",

--- a/purl/Cargo.toml
+++ b/purl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "purl"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 description = "A Package URL implementation with customizable package types"
 repository = "https://github.com/phylum-dev/purl/"


### PR DESCRIPTION
# Overview
I noticed we had made changes but not made a release in a while.

Changelog:

- Plus signs are escaped to improve compatibility with PURL implementations that incorrectly decode plus signs as spaces. (as proposed in package-url/purl-spec#261) (#14)
- Percent signs are escaped if they are contained within any component of the PURL (eg name `100%23` becomes `pkg:generic/100%2523` instead of `pkg:generic/100%23` which would parse as name `100#`) (#16)
- PURLs are parsed primarily from the right, better matching the behavior described in the PURL spec and fixing some edge cases (eg `pkg:generic/name@a%23/b%3F/c%40` gets name `name` and version `a#/b?/c@` instead of namespace `name@a#/b?` and name `c@`) (#17)

# Checklist
- [ ] Does this PR have an associated issue?
- [ ] Have you ensured that you have met the expected acceptance criteria?
- [ ] Have you created sufficient tests?

# Issue
What issue(s) does this PR close. Use the `closes #<issueNum>` here.
