### PR TITLE
Improve ergonomics for qualifier keys

### DIFF
--- a/purl/src/builder.rs
+++ b/purl/src/builder.rs
@@ -158,6 +158,12 @@ impl<T> GenericPurlBuilder<T> {
         self
     }
 
+    /// Unset all qualifiers.
+    pub fn without_qualifiers(mut self) -> Self {
+        self.parts.qualifiers.clear();
+        self
+    }
+
     /// Set the subpath.
     ///
     /// Passing `""` will unset the subpath.

--- a/purl/src/builder.rs
+++ b/purl/src/builder.rs
@@ -153,7 +153,6 @@ impl<T> GenericPurlBuilder<T> {
     pub fn without_qualifier<S>(mut self, k: S) -> Self
     where
         S: AsRef<str>,
-        SmallString: From<S>,
     {
         self.parts.qualifiers.remove(k);
         self

--- a/purl/src/qualifiers.rs
+++ b/purl/src/qualifiers.rs
@@ -315,7 +315,7 @@ impl<'a> IntoIterator for &'a mut Qualifiers {
 /// A case-insensitive qualifier name.
 ///
 /// Comparisons between this type and other types are case insensitive.
-#[derive(Clone, Debug, Default, Eq, Hash, PartialEq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Default, Eq, Hash, Ord)]
 pub struct QualifierKey(SmallString);
 
 impl<S> PartialEq<S> for QualifierKey
@@ -342,6 +342,24 @@ impl Deref for QualifierKey {
 
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+
+impl AsRef<str> for QualifierKey {
+    fn as_ref(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl From<QualifierKey> for SmallString {
+    fn from(value: QualifierKey) -> Self {
+        SmallString::from(value.0)
+    }
+}
+
+impl From<&QualifierKey> for SmallString {
+    fn from(value: &QualifierKey) -> Self {
+        SmallString::from(value.as_str())
     }
 }
 


### PR DESCRIPTION
# Overview
I was writing some code to remove qualifiers from PURLs and found that you can't do `purl.into_builder()` and then remove all the qualifiers through builder methods without cloning the `Purl` or its qualifiers and then removing them one at a time, and even then the generics and type conversions for `QualifierKey` would get in the way of calling `.without_qualifier` or `.with_qualifier` using the keys of an existing `Purl`.

This PR

- allows removing a qualifier using just any `AsRef<str>`, even one that isn't `Into<SmallString>`, because removing a qualifier never creates a string.
- adds some impls for `QualifierKey` so that it the `QualifierKey` or `&QualifierKey` of an existing `Purl` can be used as a parameter to `with_qualifier` and `without_qualifier`.
- adds a `without_qualifiers` that removes all qualifiers.

It might be nice in some cases to expose `Qualifiers::retain` somehow via `PurlBuilder` but I haven't done it in this PR. It is already possible to do that (and everything else added in this PR) by accessing the qualifiers directly:

```rust
let mut builder = purl.into_builder();
builder.parts.qualifiers.retain(|k, v| k == "checksum");
builder.build()
```

# Checklist
- [ ] Does this PR have an associated issue?
- [ ] Have you ensured that you have met the expected acceptance criteria?
- [ ] Have you created sufficient tests?

# Issue
What issue(s) does this PR close. Use the `closes #<issueNum>` here.
