### PR TITLE
Add method for parsing namespaced names

### DIFF
--- a/purl/src/lib.rs
+++ b/purl/src/lib.rs
@@ -321,6 +321,7 @@ impl<T> GenericPurl<T> {
     }
 }
 
+#[cfg(feature = "package-type")]
 impl Purl {
     /// Create a new [`PurlBuilder`] with a combined name and namespace.
     pub fn builder_with_combined_name<S>(
@@ -590,6 +591,7 @@ mod tests {
         assert_eq!(None, purl.subpath());
     }
 
+    #[cfg(feature = "package-type")]
     #[test]
     fn namespaced_name() {
         let purl =

--- a/purl/src/lib.rs
+++ b/purl/src/lib.rs
@@ -338,11 +338,11 @@ impl Purl {
                 (None, namespaced_name)
             },
             PackageType::Golang | PackageType::Npm => match namespaced_name.rsplit_once('/') {
-                Some((namespace, name)) => (Some(namespace), name.into()),
+                Some((namespace, name)) => (Some(namespace), name),
                 None => (None, namespaced_name),
             },
             PackageType::Maven => match namespaced_name.split_once(':') {
-                Some((namespace, name)) => (Some(namespace), name.into()),
+                Some((namespace, name)) => (Some(namespace), name),
                 None => (None, namespaced_name),
             },
         };

--- a/purl/src/lib.rs
+++ b/purl/src/lib.rs
@@ -152,7 +152,7 @@ impl PurlShape for String {
 /// Without type-specific functionality, it's possible to create PURLs that have
 /// incorrect capitalization or are missing a required namespace or required
 /// qualifiers.
-impl<'a> PurlShape for Cow<'a, str> {
+impl PurlShape for Cow<'_, str> {
     type Error = ParseError;
 
     fn package_type(&self) -> Cow<str> {

--- a/purl/src/lib.rs
+++ b/purl/src/lib.rs
@@ -329,10 +329,10 @@ impl Purl {
         namespaced_name: S,
     ) -> PurlBuilder
     where
-        S: Into<SmallString>,
+        S: AsRef<str>,
     {
         // Split apart namespace and name based on ecosystem.
-        let namespaced_name = namespaced_name.into();
+        let namespaced_name = namespaced_name.as_ref();
         let (namespace, name) = match package_type {
             PackageType::Cargo | PackageType::Gem | PackageType::NuGet | PackageType::PyPI => {
                 (None, namespaced_name)

--- a/purl/src/parse.rs
+++ b/purl/src/parse.rs
@@ -322,7 +322,7 @@ mod de {
 
     struct PurlVisitor<T>(PhantomData<T>);
 
-    impl<'de, T> Visitor<'de> for PurlVisitor<T>
+    impl<T> Visitor<'_> for PurlVisitor<T>
     where
         T: FromStr + PurlShape,
         <T as PurlShape>::Error: fmt::Display + From<<T as FromStr>::Err>,

--- a/purl/src/qualifiers.rs
+++ b/purl/src/qualifiers.rs
@@ -501,9 +501,9 @@ impl<'a> Iterator for Iter<'a> {
     }
 }
 
-impl<'a> ExactSizeIterator for Iter<'a> {}
+impl ExactSizeIterator for Iter<'_> {}
 
-impl<'a> DoubleEndedIterator for Iter<'a> {
+impl DoubleEndedIterator for Iter<'_> {
     fn next_back(&mut self) -> Option<Self::Item> {
         let (k, v) = self.0.next_back()?;
         Some((k, v.as_str()))
@@ -534,9 +534,9 @@ impl<'a> Iterator for IterMut<'a> {
     }
 }
 
-impl<'a> ExactSizeIterator for IterMut<'a> {}
+impl ExactSizeIterator for IterMut<'_> {}
 
-impl<'a> DoubleEndedIterator for IterMut<'a> {
+impl DoubleEndedIterator for IterMut<'_> {
     fn next_back(&mut self) -> Option<Self::Item> {
         let (k, v) = self.0.next_back()?;
         Some((k, v))

--- a/purl/src/qualifiers/well_known.rs
+++ b/purl/src/qualifiers/well_known.rs
@@ -100,7 +100,7 @@ pub struct Checksum<'a> {
     algorithms: HashMap<SmallString, Cow<'a, str>>,
 }
 
-impl<'a> KnownQualifierKey for Checksum<'a> {
+impl KnownQualifierKey for Checksum<'_> {
     const KEY: &'static str = "checksum";
 }
 
@@ -154,7 +154,7 @@ impl<'a> TryFrom<Checksum<'a>> for SmallString {
     }
 }
 
-impl<'a> Checksum<'a> {
+impl Checksum<'_> {
     /// Get a reference to the hex bytes of a hash.
     ///
     /// The hash may not be valid hex bytes.
@@ -258,7 +258,7 @@ impl<'a> ChecksumValue<'a> {
     }
 }
 
-impl<'a> Deref for ChecksumValue<'a> {
+impl Deref for ChecksumValue<'_> {
     type Target = str;
 
     fn deref(&self) -> &Self::Target {


### PR DESCRIPTION
This adds the new `Purl::builder_with_combined_name` function that allows parsing package names that include the namespace in their name.

The parsing is done according to its package type, which is why this function is only implemented for `Purl` rather than `GenericPurl<T>`.
