### PR TITLE
Add `Purl::combined_name` method

### DIFF
--- a/purl/Cargo.toml
+++ b/purl/Cargo.toml
@@ -18,7 +18,7 @@ package-type = ["phf", "unicase"]
 hex = "0.4.3"
 percent-encoding = "2.2.0"
 phf = { version = "0.11.1", features = ["macros", "unicase"], optional = true }
-serde = { version = "1.0.150", optional = true }
+serde = { version = "1.0.150", optional = true, features = ["derive"] }
 smartstring = { version = "1.0.1", optional = true }
 thiserror = "1.0.37"
 unicase = { version = "2.6.0", optional = true }

--- a/purl/src/package_type.rs
+++ b/purl/src/package_type.rs
@@ -5,6 +5,8 @@ use std::fmt;
 use std::str::FromStr;
 
 use phf::phf_map;
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 use unicase::UniCase;
 
 use crate::{
@@ -134,6 +136,8 @@ pub type PurlBuilder = GenericPurlBuilder<PackageType>;
 ///
 /// This is a subset of the types described in the PURL spec repository. See
 /// [`Purl`] for details.
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "lowercase"))]
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 #[non_exhaustive]
 pub enum PackageType {


### PR DESCRIPTION
Add `Purl::combined_name` method

This method adds the inverse of `Purl::builder_with_combined_name`,
allowing ecosystem-specific accurate printing of package names with
namespaces.

--- 

Add serde support to `PackageType`

This adds both serialization and deserialization to the `PackageType`
enum, based on its lowercase representation.

---

Two pretty small improvements, I can submit a separate PR but I thought it would be easier to just get it all over with.