### PR TITLE
Bump version to 0.1.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -310,7 +310,7 @@ dependencies = [
 
 [[package]]
 name = "purl"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "hex",
  "maplit",

--- a/purl/Cargo.toml
+++ b/purl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "purl"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 description = "A Package URL implementation with customizable package types"
 repository = "https://github.com/phylum-dev/purl/"


### PR DESCRIPTION
---

This time around I've made sure that this version has everything I could ever need for my upcoming CLI PR. So hopefully no more PURL patches (for today).