### PR TITLE
validation fixes

### DIFF
--- a/purl/src/lib.rs
+++ b/purl/src/lib.rs
@@ -381,8 +381,10 @@ fn is_valid_package_type(package_type: &str) -> bool {
     // https://github.com/package-url/purl-spec/blob/master/PURL-SPECIFICATION.rst#rules-for-each-purl-component
     const ALLOWED_SPECIAL_CHARS: &[char] = &['.', '+', '-'];
     !package_type.is_empty()
+        && package_type.starts_with(|c: char| c.is_ascii_alphabetic())
         && package_type
             .chars()
+            .skip(1)
             .all(|c| c.is_ascii_alphanumeric() || ALLOWED_SPECIAL_CHARS.contains(&c))
 }
 


### PR DESCRIPTION
# Overview
This PR tightens the validation on subpaths and package types.

Subpaths are sanitized when calling `with_subpath` to match the formatting rules: https://github.com/package-url/purl-spec/blob/7f7e82f73c38a4a339f88abf1f2aa031e9c7af23/PURL-SPECIFICATION.rst?plain=1#L313-L323

Subpaths with `%2E` segments are handled the same as `.` segments: https://github.com/package-url/purl-spec/blob/7f7e82f73c38a4a339f88abf1f2aa031e9c7af23/PURL-SPECIFICATION.rst?plain=1#L339-L347 (changed by package-url/purl-spec#394)

When using the string shapes instead of `PackageType`, the package type validation is changed to require that the type begins with a letter: https://github.com/package-url/purl-spec/blob/7f7e82f73c38a4a339f88abf1f2aa031e9c7af23/PURL-SPECIFICATION.rst?plain=1#L136

# Checklist
- [ ] Does this PR have an associated issue?
- [ ] Have you ensured that you have met the expected acceptance criteria?
- [x] Have you created sufficient tests?

# Issue
What issue(s) does this PR close. Use the `closes #<issueNum>` here.
