### PR TITLE
bump version to 0.1.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -241,7 +241,7 @@ dependencies = [
 
 [[package]]
 name = "purl"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "hex",
  "maplit",

--- a/purl/Cargo.toml
+++ b/purl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "purl"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2021"
 description = "A Package URL implementation with customizable package types"
 repository = "https://github.com/phylum-dev/purl/"


### PR DESCRIPTION
# Overview

- `with_subpath` no longer bypasses subpath canonicalization.
- The subpath `a/%2E%2E/b` parses as `a/b` instead of resulting in ParseError::InvalidEscape (matches a PURL spec change made 2025-02-19)
- type validation ensures that the first character of the type is a letter, as required by the PURL spec (only applicable when using the string shapes)
- `&` characters in qualifier values are escaped to prevent `pkg:generic/name?q=a%26b=c` turning into `pkg:generic/name?q=a&b=c`

These changes should be safe. I'm expecting that some time soon PURL will make a breaking change to canonicalization (it's basically unavoidable because the spec wasn't clear and all the implementations interpreted it differently). This may be the last release in the 0.1.x line.

# Checklist
- [ ] Does this PR have an associated issue?
- [ ] Have you ensured that you have met the expected acceptance criteria?
- [ ] Have you created sufficient tests?

# Issue
What issue(s) does this PR close. Use the `closes #<issueNum>` here.
